### PR TITLE
improvement: general changes

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,6 +36,7 @@ services:
   wordpress:
     image: nextpress/caesar-wordpress:latest
     container_name: caesar-${SLUG}-wordpress
+    user: ${UID:-1000}:${GID:-1000}
     depends_on:
       - caesar-${SLUG}-db
       - caesar-${SLUG}-cert

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,22 +5,24 @@ networks:
     external: true
     name: caesar_supervisor
   caesar_site:
-    external: true
     name: caesar_site_${SLUG}
+
+volumes:
+  wordpress:
+  database:
 
 services:
   # ---------------
   # MariaDB for the site install
-  # - THe Database
+  # - The Database
   # ---------------
   db:
     image: yobasystems/alpine-mariadb
     container_name: caesar-${SLUG}-db
     volumes:
-      - ~/.caesar/db/${SLUG}:/var/lib/mysql
-    restart: always
+      - database:/var/lib/mysql
+    restart: unless-stopped
     networks:
-      - caesar_supervisor
       - caesar_site
     environment:
       MYSQL_ROOT_PASSWORD: root
@@ -41,26 +43,18 @@ services:
       - caesar_supervisor
       - caesar_site
     volumes:
-      - $CWD_PATH/wp:/var/www/html
+      - wordpress:/var/www/html
       - $LIB_PATH/mu-plugins/autoloader.php:/var/www/html/wp-content/mu-plugins/autoloader.php:ro
       - $LIB_PATH/mu-plugins/info.php:/var/www/html/wp-content/mu-plugins/info.php:ro
       - $LIB_PATH/scripts/container:/scripts
       # - $LIB_PATH/htaccess/.htaccess-single:/var/www/html/.htaccess-single
       # - $LIB_PATH/htaccess/.htaccess-subdir:/var/www/html/.htaccess-subdir
       # - $LIB_PATH/htaccess/.htaccess-subdomain:/var/www/html/.htaccess-subdomain
-      - $CWD_PATH/wp-content/plugins:/var/www/html/wp-content/plugins
-      - $CWD_PATH/wp-content/themes:/var/www/html/wp-content/themes
-      - $CWD_PATH/wp-content/mu-plugins:/var/www/html/wp-content/mu-plugins/files
+      - $CWD_PATH/plugins:/var/www/html/wp-content/plugins
+      - $CWD_PATH/themes:/var/www/html/wp-content/themes
+      - $CWD_PATH/mu-plugins:/var/www/html/wp-content/mu-plugins/files
       - $CWD_PATH/logs/xdebug:/logs/xdebug
-
-      # Running Marker
-      # Out Products
-      - $CWD_PATH/wp-ultimo:/var/www/html/wp-content/plugins/wp-ultimo
-      
-      # - $CWD_PATH/wp-admin-pages-pro:/var/www/html/wp-content/plugins/wp-admin-pages-pro
-      # - $CWD_PATH/material-wp:/var/www/html/wp-content/plugins/material-wp
-      # - $CWD_PATH/pro-theme:/var/www/html/wp-content/plugins/pro-theme
-    restart: always
+    restart: unless-stopped
     environment:
       WORDPRESS_DB_HOST: caesar-${SLUG}-db
       WORDPRESS_DB_USER: wp
@@ -77,7 +71,6 @@ services:
     container_name: caesar-${SLUG}-cert
     networks:
       - caesar_supervisor
-      - caesar_site
     environment:
       DOMAIN: ${DOMAIN_NAME},${ADDITIONAL_DOMAIN_NAMES},${MAPPED_DOMAIN_NAMES}
     volumes:

--- a/launch.json
+++ b/launch.json
@@ -9,9 +9,8 @@
       "log": true,
       "stopOnEntry": true,
       "pathMappings": {
-        "/var/www/html": "${workspaceRoot}/wp",
-        "/var/www/html/wp-content": "${workspaceRoot}/wp-content",
-        "/var/www/html/wp-content/plugins/wp-ultimo": "${workspaceRoot}/wp-ultimo",
+        "/var/www/html/wp-content": "${workspaceRoot}",
+        "/var/www/html/wp-content/mu-plugins/files": "${workspaceRoot}/mu-plugins/files"
       }
     }
   ]

--- a/scripts/container/install-wp.sh
+++ b/scripts/container/install-wp.sh
@@ -75,11 +75,16 @@ function tap_wp_config {
 
   fi
 
+  rm /var/www/html/wp-content/plugins/index.php
+  rm /var/www/html/wp-content/plugins/hello.php
+  rm -rf /var/www/html/wp-content/plugins/akismet
+
   wp plugin install query-monitor \
     --allow-root \
     --activate-network
     
   wp plugin install debug-bar-slow-actions \
-    --allow-root
+    --allow-root \
+    --activate-network
 
 } &> /var/www/html/install.log

--- a/scripts/host/caesar-up
+++ b/scripts/host/caesar-up
@@ -110,7 +110,7 @@ export COMPOSE_PROJECT_NAME="caesar-$THE_SLUG"
 
 COMPOSER_CUSTOM_FILE=$CWD_PATH/docker-compose.override.yaml
 CUSTOM_COMPOSER_FILE_CMD=""
-if test -f "$FILE"; then
+if test -f "$COMPOSER_CUSTOM_FILE"; then
   CUSTOM_COMPOSER_FILE_CMD="-f ${COMPOSER_CUSTOM_FILE}"
 fi
 

--- a/scripts/host/caesar-up
+++ b/scripts/host/caesar-up
@@ -93,8 +93,6 @@ bash ${LIB_PATH}/scripts/host/caesar-install $1
 
 export COMPOSE_IGNORE_ORPHANS=True
 
-docker network ls | grep -q "caesar_site_$THE_SLUG" || docker network create -d bridge "caesar_site_$THE_SLUG" --label co.nextpress.caesar > /dev/null 2>&1
-
 export COMPOSE_PROJECT_NAME=caesar
 
 echo ""
@@ -110,8 +108,15 @@ start_spinner "Loading site container..."
 
 export COMPOSE_PROJECT_NAME="caesar-$THE_SLUG"
 
+COMPOSER_CUSTOM_FILE=$CWD_PATH/docker-compose.override.yaml
+CUSTOM_COMPOSER_FILE_CMD=""
+if test -f "$FILE"; then
+  CUSTOM_COMPOSER_FILE_CMD="-f ${COMPOSER_CUSTOM_FILE}"
+fi
+
 docker compose \
   -f ${LIB_PATH}/docker-compose.yaml \
+  ${CUSTOM_COMPOSER_FILE_CMD} \
   up -d --build > "$CAESAR_LOG_FILE" 2>&1
   # --build
 
@@ -200,7 +205,7 @@ mkdir ~/Documents/root-ca 2> /dev/null
   ## You copy your mkcert keys from your docker container to your localhost
   docker cp "caesar-$THE_SLUG-cert:/root/.local/share/mkcert" ~/Documents/root-ca > /dev/null 2>&1
 
-  start_spinner "Remvoing the cert-issuing container. Thanks, mkcert!"
+  start_spinner "Removing the cert-issuing container. Thanks, mkcert!"
 
   docker container rm $(docker container ls -q --filter "status=exited" --filter "name=caesar-$THE_SLUG-cert") > /dev/null 2>&1
 


### PR DESCRIPTION
General changes to repo

1. Use docker volumes for better performance and docker organization (https://docs.docker.com/storage/volumes/)
2. Change caesar_site network to use internal docker compose network as caesar_supervisor already run as external network and is attached to Wordpress container
3. Change the docker-compose restart policy to unless-stopped instead aways
4. Remove Wordpress bind mount from current dir to use a volume instead, this increases docker performance and improve current dir legibility
5. Change plugins, themes ant mu-plugins dir to current dir as we do not need wp-content directory
6. Remove akismet and hello-dolly plugins from default install
7. Add the option to use a custom docker-compose.override.yaml file with the default docker-compose.yaml file, this allows the user to add modifications to docker structure directly (https://docs.docker.com/compose/extends/)
8. Set wordpress container user as host user to avoid problems when updating or installing plugins and themes via wp-admin