### PR TITLE
fix: xdebug config

### DIFF
--- a/images/wordpress/Dockerfile
+++ b/images/wordpress/Dockerfile
@@ -4,6 +4,13 @@ RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli
   && chmod +x wp-cli.phar \
   && mv wp-cli.phar /usr/local/bin/wp
 
-RUN yes | pecl install xdebug
+RUN yes | pecl install xdebug; \
+    docker-php-ext-enable xdebug;
+
+RUN  echo "xdebug.mode=debug,develop"               >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
+  && echo "xdebug.start_with_request=yes"           >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
+  && echo "xdebug.client_port=9003"                 >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
+  && echo "xdebug.client_host=host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
+  && echo "xdebug.log='/logs/xdebug/remote.log'"    >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
 COPY . .

--- a/images/wordpress/xdebug.ini
+++ b/images/wordpress/xdebug.ini
@@ -1,9 +1,0 @@
-zend_extension = xdebug.so
-xdebug.log = "/logs/xdebug/remote.log"
-
-xdebug.mode = debug,profile,trace
-xdebug.start_with_request = yes
-xdebug.discover_client_host = 0
-xdebug.client_port = 9003
-
-xdebug.client_host=host.docker.internal

--- a/launch.json
+++ b/launch.json
@@ -7,7 +7,6 @@
       "request": "launch",
       "port": 9003,
       "log": true,
-      "stopOnEntry": true,
       "pathMappings": {
         "/var/www/html": "${workspaceRoot}/wp",
         "/var/www/html/wp-content": "${workspaceRoot}/wp-content",


### PR DESCRIPTION
This PR enables and configure the xdebug php extension in using docker-php-ext-enable

The config was also removed from workdir and inserted in docker-php-ext-xdebug.ini file directly from Dockerfile as it is a small config set to run.